### PR TITLE
[PR] Bump lodash version to fix CVE-2021-23337

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": ">=4.17.10"
+    "lodash": ">=4.17.21"
   },
   "devDependencies": {
     "publish": "0.6.0",


### PR DESCRIPTION
See https://github.com/calponia/calponia/security/dependabot/apphandler/application/yarn.lock/lodash/open